### PR TITLE
Fix default export of Header

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,6 +1,6 @@
 // ✅ First up: Header.jsx
 
-export const Header = () => (
+const Header = () => (
   <header className="fixed top-0 left-0 right-0 z-50 bg-white/95 dark:bg-gray-900/95 backdrop-blur-sm border-b border-gray-200 dark:border-gray-700">
     <div className="max-w-7xl mx-auto px-6 lg:px-8">
       <div className="flex justify-between items-center h-16">
@@ -29,3 +29,5 @@ export const Header = () => (
     </div>
   </header>
 );
+
+export default Header;


### PR DESCRIPTION
## Summary
- ensure Header exports a default component

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6854de1a908c8332bfecf8bb9077ac44